### PR TITLE
Default --device flag error

### DIFF
--- a/src/tasks/phonegap.coffee
+++ b/src/tasks/phonegap.coffee
@@ -46,7 +46,7 @@ module.exports = (grunt) ->
     config = _.defaults grunt.config.get('phonegap.config'), defaults
 
     platform = @args[0] || _.first(config.platforms)
-    device  = @args[1] || 'device'
+    device  = @args[1] || ''
 
     done = @async()
     build = new Run(grunt, config).run platform, device, -> done()

--- a/src/tasks/run.coffee
+++ b/src/tasks/run.coffee
@@ -4,7 +4,8 @@ class module.exports.Run
   constructor: (@grunt, @config) ->
 
   run: (platform, device, fn) =>
-    cmd = "phonegap local run #{platform} --device #{device} #{@_setVerbosity()}"
+    cmd = "phonegap local run #{platform} #{@_setVerbosity()}"
+    cmd += " --device #{device}" if device
     childProcess = @exec cmd, cwd: @config.path, (err, stdout, stderr) =>
       @grunt.fatal err if err
       fn(err) if fn


### PR DESCRIPTION
The --device flag causes the run task to fail when no device is detected. 'emulator' does not seem to be a valid argument.

```
Running "phonegap:run:ios:emulator" (phonegap:run) task
[phonegap] compiling iOS...
[phonegap] successfully compiled iOS app
[phonegap] installing app onto device
   [error] An error occurred while running the ios project. Targeting a device is not supported currently.
```

By default this should be empty, and the --device flag omitted from the command.
