### PR TITLE
Add .cordova directory creation to build tasks buildTree function.

### DIFF
--- a/src/tasks/build.coffee
+++ b/src/tasks/build.coffee
@@ -20,6 +20,7 @@ class module.exports.Build
     @file.mkdir @path.join(path, 'platforms')
     @file.mkdir @path.join(path, 'merges', 'android')
     @file.mkdir @path.join(path, 'www')
+    @file.mkdir @path.join(path, '.cordova')
     @
 
   cloneCordova: (fn) =>


### PR DESCRIPTION
Fixes the issue on iOS, where nothing get's copied to .cordova directory if it's not first created like other directories.
