### PR TITLE
Adds variable support for plugins and maxBuffer size

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -17,7 +17,16 @@ module.exports = (grunt) ->
         cordova: 'test/fixtures/.cordova'
         path: 'test/phonegap'
         releases: 'test/releases'
-        plugins: ['../fixtures/org.apache.cordova.core.device']
+        plugins: [
+          '../fixtures/org.apache.cordova.core.device',
+          {
+            plugin: '../fixtures/org.apache.cordova.core.variables'
+            variables: [{
+              name: 'API_KEY'
+              value: '0118 999 881 999 119 7253'
+            }]
+          }
+        ]
         platforms: ['android']
         config: 'test/fixtures/www/custom_config.xml'
         verbose: false

--- a/README.md
+++ b/README.md
@@ -42,8 +42,19 @@ grunt.initConfig({
       config: 'www/config.xml',
       cordova: '.cordova',
       path: 'phonegap',
-      plugins: ['/local/path/to/plugin', 'http://example.com/path/to/plugin.git'],
+      plugins: [
+        '/local/path/to/plugin',
+         'http://example.com/path/to/plugin.git',
+         {
+            plugin: 'http://example.com/path/to/plugin.git',
+            variables: [{
+                name: 'API_KEY',
+                value: '0118 999 881 999 119 7253'
+            }]
+         }
+      ],
       platforms: ['android'],
+      maxBuffer: 200,
       verbose: false
     }
   }

--- a/src/tasks/build.coffee
+++ b/src/tasks/build.coffee
@@ -37,8 +37,13 @@ class module.exports.Build
     @cp @config.config, @path.join(@config.path, 'www', 'config.xml'), -> fn()
 
   addPlugin: (plugin, fn) =>
-    cmd = "phonegap local plugin add #{plugin} #{@_setVerbosity()}"
-    proc = @exec cmd, cwd: @config.path, (err, stdout, stderr) =>
+    if typeof plugin is 'object'
+      cmd = "phonegap local plugin add #{plugin.plugin}"
+      cmd += " --variable #{variable.name}=\"#{variable.value}\"" for variable in plugin.variables
+      cmd += " #{@_setVerbosity()}"
+    else
+      cmd = "phonegap local plugin add #{plugin} #{@_setVerbosity()}"
+    proc = @exec cmd, {cwd: @config.path, maxBuffer: @config.maxBuffer * 1024}, (err, stdout, stderr) =>
       @fatal err if err
       fn(err) if fn
 
@@ -47,7 +52,7 @@ class module.exports.Build
 
   buildPlatform: (platform, fn) =>
     cmd = "phonegap local build #{platform} #{@_setVerbosity()}"
-    childProcess = @exec cmd, cwd: @config.path, (err, stdout, stderr) =>
+    childProcess = @exec cmd, {cwd: @config.path, maxBuffer: @config.maxBuffer * 1024}, (err, stdout, stderr) =>
       @fatal err if err
       fn(err) if fn
 

--- a/src/tasks/phonegap.coffee
+++ b/src/tasks/phonegap.coffee
@@ -14,6 +14,7 @@ module.exports = (grunt) ->
     releases: 'releases'
     plugins: []
     platforms: []
+    maxBuffer: 200
     verbose: false
 
   grunt.registerTask 'phonegap:build', 'Build as a Phonegap application', ->

--- a/src/tasks/run.coffee
+++ b/src/tasks/run.coffee
@@ -6,7 +6,7 @@ class module.exports.Run
   run: (platform, device, fn) =>
     cmd = "phonegap local run #{platform} #{@_setVerbosity()}"
     cmd += " --device #{device}" if device
-    childProcess = @exec cmd, cwd: @config.path, (err, stdout, stderr) =>
+    childProcess = @exec cmd, {cwd: @config.path, maxBuffer: @config.maxBuffer * 1024}, (err, stdout, stderr) =>
       @grunt.fatal err if err
       fn(err) if fn
 

--- a/src/test/fixtures/org.apache.cordova.core.variables/plugin.xml
+++ b/src/test/fixtures/org.apache.cordova.core.variables/plugin.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+        xmlns:rim="http://www.blackberry.com/ns/widgets"
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        id="org.apache.cordova.variables"
+        version="0.2.3">
+    <name>Device</name>
+    <description>Cordova Device Plugin</description>
+    <license>Apache 2.0</license>
+    <keywords>cordova,device</keywords>
+
+    <perference name="API_KEY" />
+
+    <!-- firefoxos -->
+    <platform name="firefoxos">
+        <config-file target="config.xml" parent="/*">
+            <feature name="Device">
+                <param name="firefoxos-package" value="Device" />
+            </feature>
+        </config-file>
+
+        <js-module src="src/firefoxos/DeviceProxy.js" name="DeviceProxy">
+            <runs />
+        </js-module>
+    </platform>
+
+    <!-- android -->
+    <platform name="android">
+        <config-file target="res/xml/config.xml" parent="/*">
+            <feature name="Device" >
+                <param name="android-package" value="org.apache.cordova.variables.Device"/>
+            </feature>
+        </config-file>
+    </platform>
+
+    <!-- ios -->
+    <platform name="ios">
+        <config-file target="config.xml" parent="/*">
+            <feature name="Device">
+                <param name="ios-package" value="CDVDevice"/>
+            </feature>
+        </config-file>
+
+        <header-file src="src/ios/CDVDevice.h" />
+        <source-file src="src/ios/CDVDevice.m" />
+    </platform>
+
+    <!-- blackberry10 -->
+    <platform name="blackberry10">
+        <source-file src="src/blackberry10/index.js" target-dir="Device" />
+        <config-file target="www/config.xml" parent="/widget">
+            <feature name="Device" value="Device"/>
+        </config-file>
+        <config-file target="www/config.xml" parent="/widget/rim:permissions">
+            <rim:permit>read_device_identifying_information</rim:permit>
+        </config-file>
+    </platform>
+
+    <!-- wp7 -->
+    <platform name="wp7">
+        <config-file target="config.xml" parent="/*">
+            <feature name="Device">
+                <param name="wp-package" value="Device"/>
+            </feature>
+        </config-file>
+
+        <config-file target="Properties/WMAppManifest.xml" parent="/Deployment/App/Capabilities">
+            <Capability Name="ID_CAP_IDENTITY_DEVICE" />
+        </config-file>
+
+        <source-file src="src/wp/Device.cs" />
+    </platform>
+
+    <!-- wp8 -->
+    <platform name="wp8">
+        <config-file target="config.xml" parent="/*">
+            <feature name="Device">
+                <param name="wp-package" value="Device"/>
+            </feature>
+        </config-file>
+
+        <config-file target="Properties/WMAppManifest.xml" parent="/Deployment/App/Capabilities">
+            <Capability Name="ID_CAP_IDENTITY_DEVICE" />
+        </config-file>
+
+        <source-file src="src/wp/Device.cs" />
+    </platform>
+
+    <!-- windows8 -->
+    <platform name="windows8">
+        <js-module src="src/windows8/DeviceProxy.js" name="DeviceProxy">
+            <merges target="" />
+        </js-module>
+    </platform>
+
+</plugin>

--- a/src/test/phonegap_build_test.coffee
+++ b/src/test/phonegap_build_test.coffee
@@ -18,8 +18,14 @@ exports.phonegap =
     test.done()
 
   'plugins should be installed': (test) ->
-    test.expect 1
+    test.expect 2
     test.ok grunt.file.isDir('test/phonegap/plugins/org.apache.cordova.core.device'), 'should add a local plugin'
+    test.ok grunt.file.isDir('test/phonegap/plugins/org.apache.cordova.core.variables'), 'should add a local plugin'
+    test.done()
+
+  'plugins can accept variables': (test) ->
+    test.expect 1
+    test.ok true
     test.done()
 
   'android platform should be built': (test) ->


### PR DESCRIPTION
This PR allows you to set variables when configuring a plugin.

```
plugins: [
    '/local/path/to/plugin',
    'http://example.com/path/to/plugin.git',
    {
        plugin: 'http://example.com/path/to/plugin.git',
        variables: [{
            name: 'API_KEY',
            value: '0118 999 881 999 119 7253'
       }]
    }
],
```

It also allows you to set the maxBuffer size for child processes as some builds go over the default buffer size on iOS.

I had problem running the tests so I've not completed work there unfortunately.
