### PR TITLE
Allows you to set the maxBuffer size for child processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ grunt.initConfig({
       path: 'phonegap',
       plugins: ['/local/path/to/plugin', 'http://example.com/path/to/plugin.git'],
       platforms: ['android'],
+      maxBuffer: 200, // You may need to raise this for iOS.
       verbose: false,
       releases: 'releases',
       releaseName: function(){

--- a/src/tasks/build.coffee
+++ b/src/tasks/build.coffee
@@ -47,7 +47,10 @@ class module.exports.Build
 
   addPlugin: (plugin, fn) =>
     cmd = "phonegap local plugin add #{plugin} #{@_setVerbosity()}"
-    proc = @exec cmd, cwd: @config.path, (err, stdout, stderr) =>
+    proc = @exec cmd, {
+      cwd: @config.path,
+      maxBuffer: @config.maxBuffer * 1024
+    }, (err, stdout, stderr) =>
       @fatal err if err
       fn(err) if fn
 
@@ -56,7 +59,10 @@ class module.exports.Build
 
   buildPlatform: (platform, fn) =>
     cmd = "phonegap local build #{platform} #{@_setVerbosity()}"
-    childProcess = @exec cmd, cwd: @config.path, (err, stdout, stderr) =>
+    childProcess = @exec cmd, {
+      cwd: @config.path,
+      maxBuffer: @config.maxBuffer * 1024
+    }, (err, stdout, stderr) =>
       @fatal err if err
       fn(err) if fn
 

--- a/src/tasks/phonegap.coffee
+++ b/src/tasks/phonegap.coffee
@@ -13,6 +13,7 @@ module.exports = (grunt) ->
     cordova: '.cordova'
     plugins: []
     platforms: []
+    maxBuffer: 200
     verbose: false
     releases: 'releases'
     releaseName: ->

--- a/src/tasks/run.coffee
+++ b/src/tasks/run.coffee
@@ -6,7 +6,10 @@ class module.exports.Run
   run: (platform, device, fn) =>
     cmd = "phonegap local run #{platform} #{@_setVerbosity()}"
     cmd += " --device #{device}" if device
-    childProcess = @exec cmd, cwd: @config.path, (err, stdout, stderr) =>
+    childProcess = @exec cmd, {
+      cwd: @config.path,
+      maxBuffer: @config.maxBuffer * 1024
+    }, (err, stdout, stderr) =>
       @grunt.fatal err if err
       fn(err) if fn
 

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -100,7 +100,8 @@
         _this = this;
       cmd = "phonegap local plugin add " + plugin + " " + (this._setVerbosity());
       proc = this.exec(cmd, {
-        cwd: this.config.path
+        cwd: this.config.path,
+        maxBuffer: this.config.maxBuffer * 1024
       }, function(err, stdout, stderr) {
         if (err) {
           _this.fatal(err);
@@ -122,7 +123,8 @@
         _this = this;
       cmd = "phonegap local build " + platform + " " + (this._setVerbosity());
       childProcess = this.exec(cmd, {
-        cwd: this.config.path
+        cwd: this.config.path,
+        maxBuffer: this.config.maxBuffer * 1024
       }, function(err, stdout, stderr) {
         if (err) {
           _this.fatal(err);

--- a/tasks/phonegap.js
+++ b/tasks/phonegap.js
@@ -13,6 +13,7 @@
       cordova: '.cordova',
       plugins: [],
       platforms: [],
+      maxBuffer: 200,
       verbose: false,
       releases: 'releases',
       releaseName: function() {

--- a/tasks/run.js
+++ b/tasks/run.js
@@ -18,7 +18,8 @@
         cmd += " --device " + device;
       }
       childProcess = this.exec(cmd, {
-        cwd: this.config.path
+        cwd: this.config.path,
+        maxBuffer: this.config.maxBuffer * 1024
       }, function(err, stdout, stderr) {
         if (err) {
           _this.grunt.fatal(err);


### PR DESCRIPTION
Some builds go over the default buffer size on iOS, as reported by both @Wedgybo and Anthony Kerz. This branch implements the maxBuffer **@config** property suggested in https://github.com/logankoester/grunt-phonegap/pull/6.
