### PR TITLE
FIX: fixAndroidVersionCode not handling the config.versionCode correctly

### DIFF
--- a/src/tasks/build.coffee
+++ b/src/tasks/build.coffee
@@ -115,8 +115,8 @@ class module.exports.Build
 
   _fixAndroidVersionCode: =>
     dom = require('xmldom').DOMParser
-    data = @grunt.config.get 'phonegap.config.versionCode'
-    versionCode = data() if @grunt.util.kindOf(data) == 'function'
+    data = @config.versionCode
+    versionCode = if @grunt.util.kindOf(data) == 'function' then data() else data
 
     manifestPath = @path.join @config.path, 'platforms', 'android', 'AndroidManifest.xml'
     manifest = @grunt.file.read manifestPath

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -216,10 +216,8 @@
     Build.prototype._fixAndroidVersionCode = function() {
       var data, doc, dom, manifest, manifestPath, versionCode;
       dom = require('xmldom').DOMParser;
-      data = this.grunt.config.get('phonegap.config.versionCode');
-      if (this.grunt.util.kindOf(data) === 'function') {
-        versionCode = data();
-      }
+      data = this.config.versionCode;
+      versionCode = this.grunt.util.kindOf(data) === 'function' ? data() : data;
       manifestPath = this.path.join(this.config.path, 'platforms', 'android', 'AndroidManifest.xml');
       manifest = this.grunt.file.read(manifestPath);
       doc = new dom().parseFromString(manifest, 'text/xml');


### PR DESCRIPTION
Hi,

The function `fixAndroidVersionCode` used to ignore the defaults for versionCode resulting in an 'undefined' value in the Android manifest. It didn't handle simple values (instead of functions) either.
This pull request fixes this.

Cheers
