### PR TITLE
Create a merges/<platform> folder for each configured platform

### DIFF
--- a/src/tasks/build.coffee
+++ b/src/tasks/build.coffee
@@ -3,6 +3,7 @@ class module.exports.Build
   cp: require 'cp'
   path: require 'path'
   exec: require('child_process').exec
+  each: require('lodash').each
 
   constructor: (@grunt, @config) ->
     @file = @grunt.file
@@ -14,13 +15,16 @@ class module.exports.Build
     if @file.exists(path) then @file.delete(path)
     @
 
-  buildTree: ->
+  buildTree: (platforms)->
     path = @config.path
     @file.mkdir @path.join(path, 'plugins')
     @file.mkdir @path.join(path, 'platforms')
-    @file.mkdir @path.join(path, 'merges', 'android')
     @file.mkdir @path.join(path, 'www')
     @file.mkdir @path.join(path, '.cordova')
+
+    @each platforms, (platform) =>
+      @file.mkdir @path.join(path, 'merges', platform)
+
     @
 
   cloneCordova: (fn) =>

--- a/src/tasks/phonegap.coffee
+++ b/src/tasks/phonegap.coffee
@@ -29,8 +29,8 @@ module.exports = (grunt) ->
     config = _.defaults grunt.config.get('phonegap.config'), defaults
 
     done = @async()
-    build = new Build(grunt, config).clean().buildTree()
     platforms = if platform then [platform] else config.platforms
+    build = new Build(grunt, config).clean().buildTree(platforms)
 
     async.series [
       build.cloneRoot,

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -10,6 +10,8 @@
 
     Build.prototype.exec = require('child_process').exec;
 
+    Build.prototype.each = require('lodash').each;
+
     function Build(grunt, config) {
       this.grunt = grunt;
       this.config = config;
@@ -38,14 +40,17 @@
       return this;
     };
 
-    Build.prototype.buildTree = function() {
-      var path;
+    Build.prototype.buildTree = function(platforms) {
+      var path,
+        _this = this;
       path = this.config.path;
       this.file.mkdir(this.path.join(path, 'plugins'));
       this.file.mkdir(this.path.join(path, 'platforms'));
-      this.file.mkdir(this.path.join(path, 'merges', 'android'));
       this.file.mkdir(this.path.join(path, 'www'));
       this.file.mkdir(this.path.join(path, '.cordova'));
+      this.each(platforms, function(platform) {
+        return _this.file.mkdir(_this.path.join(path, 'merges', platform));
+      });
       return this;
     };
 

--- a/tasks/phonegap.js
+++ b/tasks/phonegap.js
@@ -37,8 +37,8 @@
       Build = require('./build').Build;
       config = _.defaults(grunt.config.get('phonegap.config'), defaults);
       done = this.async();
-      build = new Build(grunt, config).clean().buildTree();
       platforms = platform ? [platform] : config.platforms;
+      build = new Build(grunt, config).clean().buildTree(platforms);
       return async.series([build.cloneRoot, build.cloneCordova, build.compileConfig], function() {
         return async.eachSeries(config.plugins, build.addPlugin, function(err) {
           return async.eachSeries(platforms, build.buildPlatform, function(err) {


### PR DESCRIPTION
Currently the `merges/android` folder is the only one being created. This PR changes that so it uses `config.platforms` to generate a merges folder per platform.

Some guidances on writing a proper unit test for this would be really appreciated.
