### PR TITLE
Typo creates ['p', 'l', 'a', 't', 'f', ...] merges directories

### DIFF
--- a/src/tasks/build.coffee
+++ b/src/tasks/build.coffee
@@ -17,7 +17,7 @@ module.exports = build = (grunt) ->
   run: (platforms, fn) ->
     fluid(base)
       .clean()
-      .createTree('platforms')
+      .createTree(platforms)
       .cloneRoot()
       .cloneCordova()
       .compileConfig()


### PR DESCRIPTION
Due to a typo ('platforms' instead of platforms), several one-letter merges directories were created.
