### PR TITLE
Feature: Explicit permissions list in AndroidManifest.xml

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -87,6 +87,7 @@ module.exports = (grunt) ->
         versionCode: -> 2
         targetSdkVersion: -> 18
         minSdkVersion: -> 11
+        permissions: ['ACCESS_NETWORK_STATE']
 
     # Before generating any new files, remove any previously-created files.
     clean:
@@ -177,6 +178,7 @@ module.exports = (grunt) ->
           'features/app-icons.md': 'App Icons'
           'features/version-code.md': 'versionCode'
           'features/sdk-version.md': 'minSdkVersion and targetSdkVersion'
+          'features/permissions.md': 'Android Permissions'
           'features/phonegap-build.md': 'Phonegap Build'
           'tasks.md': 'Tasks'
           'test-suite.md': 'Running the test suite'

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ subdirectory containing the Phonegap project, which gets regenerated every time 
 * [App Icons](#app-icons)
 * [versionCode](#versioncode)
 * [minSdkVersion and targetSdkVersion](#minsdkversion-and-targetsdkversion)
+* [Android Permissions](#android-permissions)
 * [Phonegap Build](#phonegap-build)
 * [Tasks](#tasks)
 * [Running the test suite](#running-the-test-suite)
@@ -193,7 +194,11 @@ grunt.initConfig({
         username: 'your_username',
         password: 'your_password',
         platforms: ['android', 'blackberry', 'ios', 'symbian', 'webos', 'wp7']
-      }
+      },
+
+      // Set an explicit Android permissions list to override the automatic plugin defaults.
+      // In most cases, you should omit this setting. See 'Android Permissions' in README.md for details.
+      permissions: ['INTERNET', 'ACCESS_COURSE_LOCATION', '...']
     }
   }
 })
@@ -333,6 +338,37 @@ If you set `phonegap.config.minSdkVersion` and/or `phonegap.config.targetSdkVers
 `AndroidManifest.xml` file and set it for you.
 
 This option will be ignored for non-Android platforms or when using the remote build service. For remote Android builds, instead try the `android-targetSdkVersion` preference mentioned above.
+
+
+## Android Permissions
+[[Back To Top]](#grunt-phonegap)
+
+If `phonegap.config.permissions` is omitted, plugin permissions will be set automatically by Phonegap. In most cases, this is what you want.
+
+Ordinarily with Phonegap (local), permissions for the Android platform are written to `AndroidManifest.xml`
+based on the requirements of the plugins that you have added to your project, so you do not have to worry
+about them.
+
+In some (perhaps unusual) situations, you may want to alter these permissions without modifying a plugin.
+
+When you may want to do this:
+
+* To reserve not-yet-used permissions during development
+* To enable a plugin that does not require the right permissions for your target version of Android
+* While troubleshooting a permissions error in your app.
+* When using an advanced Grunt workflow to set your permissions for different builds dynamically (by specifying `phonegap.config.permissions` as a function)
+
+If you need this feature, set `phonegap.config.permissions` to an array of permission basenames, such as ['ACCESS_NETWORK_STATE'].
+
+When `phonegap.config.permissions` is set, **all permissions added by Cordova + plugins will be removed**, giving
+you complete control over the permission manifest.
+
+This means you need to explicitely add any permissions required by plugins, or your app will not work.
+
+Be careful to check any permissions your plugins need before adding this feature to your app, and remember to update it
+when adding additional plugins later.
+
+If you are using the Phonegap Build cloud service for the Android platform, this setting will have no effect.
 
 
 ## Phonegap Build

--- a/docs/features/permissions.md
+++ b/docs/features/permissions.md
@@ -1,0 +1,26 @@
+If `phonegap.config.permissions` is omitted, plugin permissions will be set automatically by Phonegap. In most cases, this is what you want.
+
+Ordinarily with Phonegap (local), permissions for the Android platform are written to `AndroidManifest.xml`
+based on the requirements of the plugins that you have added to your project, so you do not have to worry
+about them.
+
+In some (perhaps unusual) situations, you may want to alter these permissions without modifying a plugin.
+
+When you may want to do this:
+
+* To reserve not-yet-used permissions during development
+* To enable a plugin that does not require the right permissions for your target version of Android
+* While troubleshooting a permissions error in your app.
+* When using an advanced Grunt workflow to set your permissions for different builds dynamically (by specifying `phonegap.config.permissions` as a function)
+
+If you need this feature, set `phonegap.config.permissions` to an array of permission basenames, such as ['ACCESS_NETWORK_STATE'].
+
+When `phonegap.config.permissions` is set, **all permissions added by Cordova + plugins will be removed**, giving
+you complete control over the permission manifest.
+
+This means you need to explicitely add any permissions required by plugins, or your app will not work.
+
+Be careful to check any permissions your plugins need before adding this feature to your app, and remember to update it
+when adding additional plugins later.
+
+If you are using the Phonegap Build cloud service for the Android platform, this setting will have no effect.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -124,7 +124,11 @@ grunt.initConfig({
         username: 'your_username',
         password: 'your_password',
         platforms: ['android', 'blackberry', 'ios', 'symbian', 'webos', 'wp7']
-      }
+      },
+
+      // Set an explicit Android permissions list to override the automatic plugin defaults.
+      // In most cases, you should omit this setting. See 'Android Permissions' in README.md for details.
+      permissions: ['INTERNET', 'ACCESS_COURSE_LOCATION', '...']
     }
   }
 })

--- a/src/tasks/build/after/local/android.coffee
+++ b/src/tasks/build/after/local/android.coffee
@@ -7,12 +7,14 @@ module.exports = android = (grunt) ->
     buildScreens: require('./android/screens')(grunt).build
     setMinSdkVersion: require('./android/sdk_version')(grunt).setMin
     setTargetSdkVersion: require('./android/sdk_version')(grunt).setTarget
+    setPermissions: require('./android/permissions')(grunt).set
 
   run: (fn) ->
     fluid(tasks)
       .repairVersionCode()
       .setMinSdkVersion()
       .setTargetSdkVersion()
+      .setPermissions()
       .buildIcons()
       .buildScreens()
       .go (err, result) ->

--- a/src/tasks/build/after/local/android/permissions.coffee
+++ b/src/tasks/build/after/local/android/permissions.coffee
@@ -1,0 +1,32 @@
+_ = require 'lodash'
+xmldom = require 'xmldom'
+path = require 'path'
+
+module.exports = permissions = (grunt) ->
+  helpers = require('../../../../helpers')(grunt)
+
+  set: (fn) ->
+    dom = xmldom.DOMParser
+    permissions = helpers.config 'permissions'
+    if permissions
+      phonegapPath = helpers.config 'path'
+
+      manifestPath = path.join phonegapPath, 'platforms', 'android', 'AndroidManifest.xml'
+      manifest = grunt.file.read manifestPath
+      grunt.log.writeln "Adding permissions to '#{manifestPath}'"
+      doc = new dom().parseFromString manifest, 'text/xml'
+
+      # Remove existing permissions (added by Cordova + plugins). You should add these
+      # back in your grunt-phonegap config, unless you are absolutely sure you want to remove them.
+      _.each doc.getElementsByTagName('uses-permission'), (el) ->
+        el.parentNode.removeChild(el)
+
+      manifestElement = doc.getElementsByTagName('manifest').item(0)
+      _.each permissions, (permission) ->
+        p = doc.createElement('uses-permission')
+        p.setAttribute('android:name', "android.permission.#{permission}")
+        manifestElement.appendChild p
+
+      grunt.file.write manifestPath, doc
+
+    if fn then fn()

--- a/src/test/build/android/build_test.coffee
+++ b/src/test/build/android/build_test.coffee
@@ -18,30 +18,3 @@ exports.phonegap =
     name = grunt.config.get('phonegap.config.config.data.name')
     test.ok grunt.file.isFile("test/phonegap/platforms/android/bin/#{name}-debug.apk"), 'debug apk should be created'
     test.done()
-
-  'versionCode in AndroidManifest.xml should match config.versionCode': (test) ->
-    test.expect 1
-    data = grunt.config.get 'phonegap.config.versionCode'
-    versionCode = data() if grunt.util.kindOf(data) == 'function'
-    xml = grunt.file.read 'test/phonegap/platforms/android/AndroidManifest.xml'
-    manifest = xmlParser.toJson xml, object: true
-    test.equal versionCode, manifest['manifest']['android:versionCode'], 'versionCode value should match'
-    test.done()
-
-  'targetSdkVersion in AndroidManifest.xml should match config.targetSdkVersion': (test) ->
-    test.expect 1
-    data = grunt.config.get 'phonegap.config.targetSdkVersion'
-    targetSdkVersion = data() if grunt.util.kindOf(data) == 'function'
-    xml = grunt.file.read 'test/phonegap/platforms/android/AndroidManifest.xml'
-    manifest = xmlParser.toJson xml, object: true
-    test.equal targetSdkVersion, manifest['manifest']['uses-sdk']['android:targetSdkVersion'], 'targetSdkVersion value should match'
-    test.done()
-
-  'minSdkVersion in AndroidManifest.xml should match config.minSdkVersion': (test) ->
-    test.expect 1
-    data = grunt.config.get 'phonegap.config.minSdkVersion'
-    minSdkVersion = data() if grunt.util.kindOf(data) == 'function'
-    xml = grunt.file.read 'test/phonegap/platforms/android/AndroidManifest.xml'
-    manifest = xmlParser.toJson xml, object: true
-    test.equal minSdkVersion, manifest['manifest']['uses-sdk']['android:minSdkVersion'], 'targetSdkVersion value should match'
-    test.done()

--- a/src/test/build/android/permissions_test.coffee
+++ b/src/test/build/android/permissions_test.coffee
@@ -1,0 +1,34 @@
+grunt = require 'grunt'
+xmldom = require 'xmldom'
+path = require 'path'
+_ = require 'lodash'
+dom = xmldom.DOMParser
+
+exports.phonegap =
+  'The INTERNET permission should be removed': (test) ->
+    test.expect 1
+
+    manifest = grunt.file.read 'test/phonegap/platforms/android/AndroidManifest.xml'
+    doc = new dom().parseFromString manifest, 'text/xml'
+    permissions = doc.getElementsByTagName('uses-permission')
+
+    matches = _.find permissions, (permission) ->
+      permission.getAttribute('android:name') == 'android.permission.INTERNET'
+    test.equal matches, undefined
+
+    test.done()
+
+  'The ACCESS_NETWORK_STATE permission should be added': (test) ->
+    test.expect 2
+
+    manifest = grunt.file.read 'test/phonegap/platforms/android/AndroidManifest.xml'
+    doc = new dom().parseFromString manifest, 'text/xml'
+    permissions = doc.getElementsByTagName('uses-permission')
+
+    matches = _.find permissions, (permission) ->
+      permission.getAttribute('android:name') == 'android.permission.ACCESS_NETWORK_STATE'
+    test.ok matches
+    test.equal matches.nodeName, 'uses-permission'
+
+    test.done()
+

--- a/src/test/build/android/sdk_version_test.coffee
+++ b/src/test/build/android/sdk_version_test.coffee
@@ -1,0 +1,22 @@
+grunt = require 'grunt'
+xmlParser = require 'xml2json'
+path = require 'path'
+
+exports.phonegap =
+  'targetSdkVersion in AndroidManifest.xml should match config.targetSdkVersion': (test) ->
+    test.expect 1
+    data = grunt.config.get 'phonegap.config.targetSdkVersion'
+    targetSdkVersion = data() if grunt.util.kindOf(data) == 'function'
+    xml = grunt.file.read 'test/phonegap/platforms/android/AndroidManifest.xml'
+    manifest = xmlParser.toJson xml, object: true
+    test.equal targetSdkVersion, manifest['manifest']['uses-sdk']['android:targetSdkVersion'], 'targetSdkVersion value should match'
+    test.done()
+
+  'minSdkVersion in AndroidManifest.xml should match config.minSdkVersion': (test) ->
+    test.expect 1
+    data = grunt.config.get 'phonegap.config.minSdkVersion'
+    minSdkVersion = data() if grunt.util.kindOf(data) == 'function'
+    xml = grunt.file.read 'test/phonegap/platforms/android/AndroidManifest.xml'
+    manifest = xmlParser.toJson xml, object: true
+    test.equal minSdkVersion, manifest['manifest']['uses-sdk']['android:minSdkVersion'], 'targetSdkVersion value should match'
+    test.done()

--- a/src/test/build/android/version_code_test.coffee
+++ b/src/test/build/android/version_code_test.coffee
@@ -1,0 +1,16 @@
+# If you set a `phonegap.config.versionCode` value (function or literal), `grunt phonegap:build` will post-process the generated
+# `AndroidManifest.xml` file and set it for you.
+
+grunt = require 'grunt'
+xmlParser = require 'xml2json'
+path = require 'path'
+
+exports.phonegap =
+  'versionCode in AndroidManifest.xml should match config.versionCode': (test) ->
+    test.expect 1
+    data = grunt.config.get 'phonegap.config.versionCode'
+    versionCode = data() if grunt.util.kindOf(data) == 'function'
+    xml = grunt.file.read 'test/phonegap/platforms/android/AndroidManifest.xml'
+    manifest = xmlParser.toJson xml, object: true
+    test.equal versionCode, manifest['manifest']['android:versionCode'], 'versionCode value should match'
+    test.done()

--- a/tasks/build/after/local/android.js
+++ b/tasks/build/after/local/android.js
@@ -10,11 +10,12 @@
       buildIcons: require('./android/icons')(grunt).build,
       buildScreens: require('./android/screens')(grunt).build,
       setMinSdkVersion: require('./android/sdk_version')(grunt).setMin,
-      setTargetSdkVersion: require('./android/sdk_version')(grunt).setTarget
+      setTargetSdkVersion: require('./android/sdk_version')(grunt).setTarget,
+      setPermissions: require('./android/permissions')(grunt).set
     };
     return {
       run: function(fn) {
-        return fluid(tasks).repairVersionCode().setMinSdkVersion().setTargetSdkVersion().buildIcons().buildScreens().go(function(err, result) {
+        return fluid(tasks).repairVersionCode().setMinSdkVersion().setTargetSdkVersion().setPermissions().buildIcons().buildScreens().go(function(err, result) {
           if (err) {
             grunt.fatal(err);
           }

--- a/tasks/build/after/local/android/permissions.js
+++ b/tasks/build/after/local/android/permissions.js
@@ -1,0 +1,43 @@
+(function() {
+  var path, permissions, xmldom, _;
+
+  _ = require('lodash');
+
+  xmldom = require('xmldom');
+
+  path = require('path');
+
+  module.exports = permissions = function(grunt) {
+    var helpers;
+    helpers = require('../../../../helpers')(grunt);
+    return {
+      set: function(fn) {
+        var doc, dom, manifest, manifestElement, manifestPath, phonegapPath;
+        dom = xmldom.DOMParser;
+        permissions = helpers.config('permissions');
+        if (permissions) {
+          phonegapPath = helpers.config('path');
+          manifestPath = path.join(phonegapPath, 'platforms', 'android', 'AndroidManifest.xml');
+          manifest = grunt.file.read(manifestPath);
+          grunt.log.writeln("Adding permissions to '" + manifestPath + "'");
+          doc = new dom().parseFromString(manifest, 'text/xml');
+          _.each(doc.getElementsByTagName('uses-permission'), function(el) {
+            return el.parentNode.removeChild(el);
+          });
+          manifestElement = doc.getElementsByTagName('manifest').item(0);
+          _.each(permissions, function(permission) {
+            var p;
+            p = doc.createElement('uses-permission');
+            p.setAttribute('android:name', "android.permission." + permission);
+            return manifestElement.appendChild(p);
+          });
+          grunt.file.write(manifestPath, doc);
+        }
+        if (fn) {
+          return fn();
+        }
+      }
+    };
+  };
+
+}).call(this);


### PR DESCRIPTION
In #53, @olanod requested the ability to set any property in `AndroidManifest.xml` through the `grunt-phonegap` config object, giving explicit permissions as a use case example.

I'm hesitant to go that far, but that particular use case is valid and one that I have encountered as well, so I have implemented the ability to set the permissions list manually in this way.

See [permissions.md](https://github.com/logankoester/grunt-phonegap/blob/c8bcdd9f0cc4ab105046371b86c3ae942777ca7e/docs/features/permissions.md) for documentation.
