### PR TITLE
Locking Android screen orientation using AndroidManifest.xml's activity element

### DIFF
--- a/src/tasks/build/after/local/android.coffee
+++ b/src/tasks/build/after/local/android.coffee
@@ -9,6 +9,7 @@ module.exports = android = (grunt) ->
     setTargetSdkVersion: require('./android/sdk_version')(grunt).setTarget
     setPermissions: require('./android/permissions')(grunt).set
     setAndroidApplicationName: require('./android/application_name')(grunt).set
+    setScreenOrientation: require('./android/screen_orientation')(grunt).set
 
   run: (fn) ->
     fluid(tasks)
@@ -19,6 +20,7 @@ module.exports = android = (grunt) ->
       .setAndroidApplicationName()
       .buildIcons()
       .buildScreens()
+      .setScreenOrientation()
       .go (err, result) ->
         if err then grunt.fatal err
         if fn then fn()

--- a/src/tasks/build/after/local/android/screen_orientation.coffee
+++ b/src/tasks/build/after/local/android/screen_orientation.coffee
@@ -1,0 +1,23 @@
+xmldom = require 'xmldom'
+path = require 'path'
+
+module.exports = screenOrientation = (grunt) ->
+  helpers = require('../../../../helpers')(grunt)
+
+  set: (fn) ->
+    dom = xmldom.DOMParser
+    
+    screenOrientation = helpers.config 'screenOrientation'
+    if screenOrientation
+      phonegapPath = helpers.config 'path'
+      manifestPath = path.join phonegapPath, 'platforms', 'android', 'AndroidManifest.xml'
+      manifest = grunt.file.read manifestPath
+      grunt.log.writeln "Setting screenOrientation to #{screenOrientation} in #{manifestPath}"
+
+      doc = new dom().parseFromString manifest, 'text/xml'
+      activity = doc.getElementsByTagName('activity')[0];
+      activity.setAttribute 'android:screenOrientation', screenOrientation
+
+      grunt.file.write manifestPath, doc
+
+    if fn then fn()

--- a/src/test/build/android/screen_orientation_test.coffee
+++ b/src/test/build/android/screen_orientation_test.coffee
@@ -1,0 +1,17 @@
+grunt = require 'grunt'
+xmlParser = require 'xml2json'
+path = require 'path'
+helpers = require(path.join __dirname, '..', '..', '..', 'tasks', 'helpers')(grunt)
+
+if helpers.canBuild 'android'
+
+  exports.phonegap =
+    '<activity android:screenOrientation> in AndroidManifest.xml should match config.screenOrientation': (test) ->
+      test.expect 1
+      data = grunt.config.get 'phonegap.config.screenOrientation'
+      screenOrientation = if grunt.util.kindOf(data) == 'function' then data() else data
+      xml = grunt.file.read 'test/phonegap/platforms/android/AndroidManifest.xml'
+      manifest = xmlParser.toJson xml, object: true
+      manifestActivityScreenOrientation = manifest['manifest']['application']['activity']['android:screenOrientation']
+      test.equal screenOrientation, manifestActivityScreenOrientation, 'android:screenOrientation value should match'
+      test.done()

--- a/tasks/build/after/local/android.js
+++ b/tasks/build/after/local/android.js
@@ -12,11 +12,12 @@
       setMinSdkVersion: require('./android/sdk_version')(grunt).setMin,
       setTargetSdkVersion: require('./android/sdk_version')(grunt).setTarget,
       setPermissions: require('./android/permissions')(grunt).set,
-      setAndroidApplicationName: require('./android/application_name')(grunt).set
+      setAndroidApplicationName: require('./android/application_name')(grunt).set,
+      setScreenOrientation: require('./android/screen_orientation')(grunt).set
     };
     return {
       run: function(fn) {
-        return fluid(tasks).repairVersionCode().setMinSdkVersion().setTargetSdkVersion().setPermissions().setAndroidApplicationName().buildIcons().buildScreens().go(function(err, result) {
+        return fluid(tasks).repairVersionCode().setMinSdkVersion().setTargetSdkVersion().setPermissions().setAndroidApplicationName().buildIcons().buildScreens().setScreenOrientation().go(function(err, result) {
           if (err) {
             grunt.fatal(err);
           }

--- a/tasks/build/after/local/android/screen_orientation.js
+++ b/tasks/build/after/local/android/screen_orientation.js
@@ -1,0 +1,33 @@
+(function() {
+  var path, screenOrientation, xmldom;
+
+  xmldom = require('xmldom');
+
+  path = require('path');
+
+  module.exports = screenOrientation = function(grunt) {
+    var helpers;
+    helpers = require('../../../../helpers')(grunt);
+    return {
+      set: function(fn) {
+        var activity, doc, dom, manifest, manifestPath, phonegapPath;
+        dom = xmldom.DOMParser;
+        screenOrientation = helpers.config('screenOrientation');
+        if (screenOrientation) {
+          phonegapPath = helpers.config('path');
+          manifestPath = path.join(phonegapPath, 'platforms', 'android', 'AndroidManifest.xml');
+          manifest = grunt.file.read(manifestPath);
+          grunt.log.writeln("Setting screenOrientation to " + screenOrientation + " in " + manifestPath);
+          doc = new dom().parseFromString(manifest, 'text/xml');
+          activity = doc.getElementsByTagName('activity')[0];
+          activity.setAttribute('android:screenOrientation', screenOrientation);
+          grunt.file.write(manifestPath, doc);
+        }
+        if (fn) {
+          return fn();
+        }
+      }
+    };
+  };
+
+}).call(this);


### PR DESCRIPTION
Adding the ability to lock Android's screen orientation by modifying the AndroidManifest file.

```
<manifest>
  <application>
    <activity android:screenOrientation='portrait'>

    </activity>
  </application>
</manifest>
```
