### PR TITLE
Replaces directory-copy with ncp

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,12 +52,12 @@
     "cordova"
   ],
   "dependencies": {
-    "directory-copy": ">= 0.1.0",
     "async": "~0.8.0",
     "cp": "~0.1.1",
     "xmldom": "~0.1.16",
     "lodash": "~2.4.1",
     "fluid": "~0.1.3",
-    "URIjs": "^1.12.0"
+    "URIjs": "^1.12.0",
+    "ncp": "^0.5.1"
   }
 }

--- a/src/tasks/build/base/clone_cordova.coffee
+++ b/src/tasks/build/base/clone_cordova.coffee
@@ -1,5 +1,5 @@
 path = require 'path'
-copy = require 'directory-copy'
+ncp = require('ncp').ncp
 
 module.exports = cloneCordova = (grunt) ->
   helpers = require('../../helpers')(grunt)
@@ -8,6 +8,6 @@ module.exports = cloneCordova = (grunt) ->
     grunt.log.writeln 'Cloning .cordova directory'
     cordovaPath = helpers.config 'cordova'
     phonegapPath = helpers.config 'path'
-    copy src: cordovaPath, dest: path.join(phonegapPath, '.cordova'), (err) =>
+    ncp cordovaPath, path.join(phonegapPath, '.cordova'), { stopOnError: true }, (err) =>
       if err then grunt.warn err
       if fn then fn err

--- a/src/tasks/build/base/clone_root.coffee
+++ b/src/tasks/build/base/clone_root.coffee
@@ -1,5 +1,5 @@
 path = require 'path'
-copy = require 'directory-copy'
+ncp = require('ncp').ncp
 
 module.exports = cloneRoot = (grunt) ->
   helpers = require('../../helpers')(grunt)
@@ -8,6 +8,6 @@ module.exports = cloneRoot = (grunt) ->
     rootPath = helpers.config 'root'
     phonegapPath = helpers.config 'path'
 
-    copy src: rootPath, dest: path.join(phonegapPath, 'www'), (err) =>
+    ncp rootPath, path.join(phonegapPath, 'www'), { stopOnError: true }, (err) =>
       if err then grunt.warn err
       if fn then fn err

--- a/tasks/build/base/clone_cordova.js
+++ b/tasks/build/base/clone_cordova.js
@@ -1,9 +1,9 @@
 (function() {
-  var cloneCordova, copy, path;
+  var cloneCordova, ncp, path;
 
   path = require('path');
 
-  copy = require('directory-copy');
+  ncp = require('ncp').ncp;
 
   module.exports = cloneCordova = function(grunt) {
     var helpers;
@@ -14,9 +14,8 @@
         grunt.log.writeln('Cloning .cordova directory');
         cordovaPath = helpers.config('cordova');
         phonegapPath = helpers.config('path');
-        return copy({
-          src: cordovaPath,
-          dest: path.join(phonegapPath, '.cordova')
+        return ncp(cordovaPath, path.join(phonegapPath, '.cordova'), {
+          stopOnError: true
         }, (function(_this) {
           return function(err) {
             if (err) {

--- a/tasks/build/base/clone_root.js
+++ b/tasks/build/base/clone_root.js
@@ -1,9 +1,9 @@
 (function() {
-  var cloneRoot, copy, path;
+  var cloneRoot, ncp, path;
 
   path = require('path');
 
-  copy = require('directory-copy');
+  ncp = require('ncp').ncp;
 
   module.exports = cloneRoot = function(grunt) {
     var helpers;
@@ -14,9 +14,8 @@
         grunt.log.writeln('Cloning root directory');
         rootPath = helpers.config('root');
         phonegapPath = helpers.config('path');
-        return copy({
-          src: rootPath,
-          dest: path.join(phonegapPath, 'www')
+        return ncp(rootPath, path.join(phonegapPath, 'www'), {
+          stopOnError: true
         }, (function(_this) {
           return function(err) {
             if (err) {


### PR DESCRIPTION
`directory-copy` is not able to handle folders with many files (see test script below). `ncp` looks like a solid alternative.

---

```
var fs = require('fs'),
    copy = require('directory-copy');

try {
    fs.mkdirSync('./test');
} catch(e) {}

try {
    fs.mkdirSync('./test2');
} catch(e) {}

for (var i = 0; i < 1000; i++) {
    fs.writeFileSync('./test/test-' + i, 'a');
}

copy({ src: './test', dest: './test2'}, function (err) {
    console.log(err);
})
```
