### PR TITLE
Added basic firefoxOS support

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -19,7 +19,7 @@ module.exports = (grunt) ->
         name: 'TestFixtureApp'
         path: 'test/phonegap'
         plugins: ['./test/fixtures/org.apache.cordova.core.device']
-        platforms: ['android', 'ios']
+        platforms: ['android', 'ios', 'firefoxos']
         debuggable: false
 
         config:

--- a/src/tasks/helpers.coffee
+++ b/src/tasks/helpers.coffee
@@ -12,10 +12,11 @@ exec = require('child_process').exec
 # @return [Boolean] true When it is possible to build from this environment.
 # @return [Boolean] false When it is not possible to build from this environment from this environment.
 canBuild = (targetPlatform) ->
-  compatibility = 
+  compatibility =
     'amazon-fireos': ['darwin', 'win32', 'linux']
     'android': ['darwin', 'win32', 'linux']
     'blackberry10': ['darwin', 'win32']
+    'firefoxos': ['darwin', 'win32', 'linux']
     'ios': ['darwin']
     'ubuntu': ['linux'] # Specifically Ubuntu
     'wp7': ['win32']

--- a/tasks/helpers.js
+++ b/tasks/helpers.js
@@ -12,6 +12,7 @@
       'amazon-fireos': ['darwin', 'win32', 'linux'],
       'android': ['darwin', 'win32', 'linux'],
       'blackberry10': ['darwin', 'win32'],
+      'firefoxos': ['darwin', 'win32', 'linux'],
       'ios': ['darwin'],
       'ubuntu': ['linux'],
       'wp7': ['win32'],


### PR DESCRIPTION
Added firefoxOS to the compatibility list as suggested in #91
It prepares the firefox OS platform as expected.
Now if someone could create tests and add a way to automatically generate the [manifest.webapp](https://developer.mozilla.org/en-US/Apps/Build/Manifest) file from the phonegap config, it'd be great.

Output of `grunt build` as requested:

```
[4mRunning "clean:tasks" (clean) task[24m
Cleaning tasks...[32mOK[39m

[4mRunning "clean:test" (clean) task[24m
Cleaning test...[32mOK[39m

[4mRunning "copy:test_fixtures" (copy) task[24m
Created [36m2[39m directories, copied [36m37[39m files

[4mRunning "copy:test_cordova" (copy) task[24m
Copied [36m1[39m files

[4mRunning "coffee:tasks" (coffee) task[24m

[4mRunning "coffee:test" (coffee) task[24m

[4mRunning "readme_generator:readme" (readme_generator) task[24m
[32m>> [39mGetting package info from options...
[32m>> [39mNo need to get package info...
[32m>> [39mGenerating banner to place on the very top...
[32m>> [39mGenerating table of contents, you won't get lost...
[32m>> [39mDigging the past for release information...
[32m>> [39mGetting the latest changelog from the changelogs folder...
Your readme file "README.md" is ready!
[32mOK[39m

[32mDone, without errors.[39m
```

Thanks
