### PR TITLE
Add config.androidManifest to override AndroidManifest.xml <application> and <activity>

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -37,7 +37,11 @@ module.exports = (grunt) ->
         verbose: false
         releases: 'test/releases'
         releaseName: 'TestFixtureApp-0.0.0'
-
+        androidManifest: 
+          application:
+            'applicationKey' : 'applicationValue'
+          activity:
+            'activityKey' : 'activityValue'
         key:
           store: 'test/fixtures/release.keystore'
           alias: 'release'

--- a/README.md
+++ b/README.md
@@ -210,6 +210,14 @@ grunt.initConfig({
         }
       },
 
+      // A list of resources to be copied.
+      resources : {
+        android : [{
+          from : 'phonegap/res/files/android', 
+          to   : 'res'}
+        ]
+      },
+
       // Android-only integer version to increase with each release.
       // See http://developer.android.com/tools/publishing/versioning.html
       versionCode: function(){ return(1) },

--- a/README.md
+++ b/README.md
@@ -119,7 +119,16 @@ grunt.initConfig({
         return(pkg.name + '-' + pkg.version);
       },
       debuggable: false,
-
+      // custom properties overriding AndroidManifest.xml
+      androidManifest: {
+        // properties added to <application>
+        application : {
+        },
+        // properties added to <activity>
+        activity : {
+          "android:launchMode":"singleTask" // This is necessary to force single app instance.
+        }
+      },
       // Must be set for ios to work.
       // Should return the app name.
       name: function(){

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ grunt.initConfig({
           // landscape version
           xhdpiLand: 'www/screen-xhdpi-landscape.png'
         },
+        wp8: 'SplashScreenImage.jpg',
         ios: {
           // ipad landscape
           ipadLand: 'screen-ipad-landscape.png',

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -28,7 +28,16 @@ grunt.initConfig({
         return(pkg.name + '-' + pkg.version);
       },
       debuggable: false,
-
+      // custom properties overriding AndroidManifest.xml
+      androidManifest: {
+        // properties added to <application>
+        application : {
+        },
+        // properties added to <activity>
+        activity : {
+          "android:launchMode":"singleTask" // This is necessary to force single app instance.
+        }
+      },
       // Must be set for ios to work.
       // Should return the app name.
       name: function(){

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -119,6 +119,14 @@ grunt.initConfig({
         }
       },
 
+      // A list of resources to be copied.
+      resources : {
+        android : [{
+          from : 'phonegap/res/files/android', 
+          to   : 'res'}
+        ]
+      },
+
       // Android-only integer version to increase with each release.
       // See http://developer.android.com/tools/publishing/versioning.html
       versionCode: function(){ return(1) },

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -104,6 +104,7 @@ grunt.initConfig({
           // landscape version
           xhdpiLand: 'www/screen-xhdpi-landscape.png'
         },
+        wp8: 'SplashScreenImage.jpg',
         ios: {
           // ipad landscape
           ipadLand: 'screen-ipad-landscape.png',

--- a/src/tasks/build/after/local/android.coffee
+++ b/src/tasks/build/after/local/android.coffee
@@ -9,6 +9,7 @@ module.exports = android = (grunt) ->
     setTargetSdkVersion: require('./android/sdk_version')(grunt).setTarget
     setPermissions: require('./android/permissions')(grunt).set
     setAndroidApplicationName: require('./android/application_name')(grunt).set
+    setManfifestParams: require('./android/manifest_params')(grunt).set
     setScreenOrientation: require('./android/screen_orientation')(grunt).set
     setDebuggable: require('./android/debuggable')(grunt).set
 
@@ -19,6 +20,7 @@ module.exports = android = (grunt) ->
       .setTargetSdkVersion()
       .setPermissions()
       .setAndroidApplicationName()
+      .setManfifestParams()
       .buildIcons()
       .buildScreens()
       .setScreenOrientation()

--- a/src/tasks/build/after/local/android.coffee
+++ b/src/tasks/build/after/local/android.coffee
@@ -5,6 +5,7 @@ module.exports = android = (grunt) ->
     repairVersionCode: require('./android/version_code')(grunt).repair
     buildIcons: require('./android/icons')(grunt).build
     buildScreens: require('./android/screens')(grunt).build
+    buildResources: require('./android/resources')(grunt).build
     setMinSdkVersion: require('./android/sdk_version')(grunt).setMin
     setTargetSdkVersion: require('./android/sdk_version')(grunt).setTarget
     setPermissions: require('./android/permissions')(grunt).set
@@ -23,6 +24,7 @@ module.exports = android = (grunt) ->
       .setManfifestParams()
       .buildIcons()
       .buildScreens()
+      .buildResources()
       .setScreenOrientation()
       .setDebuggable()
       .go (err, result) ->

--- a/src/tasks/build/after/local/android/manifest_params.coffee
+++ b/src/tasks/build/after/local/android/manifest_params.coffee
@@ -1,0 +1,30 @@
+xmldom = require 'xmldom'
+path = require 'path'
+
+module.exports = applicationName = (grunt) ->
+  helpers = require('../../../../helpers')(grunt)
+
+  set: (fn) ->
+    dom = xmldom.DOMParser
+    manifestParams = helpers.config 'androidManifest'
+    if manifestParams
+      phonegapPath = helpers.config 'path'
+
+      manifestPath = path.join phonegapPath, 'platforms', 'android', 'AndroidManifest.xml'
+      manifest = grunt.file.read manifestPath
+      grunt.log.writeln "Setting manifest params in '#{manifestPath}' to #{manifestParams}"
+      doc = new dom().parseFromString manifest, 'text/xml'
+      applicationElem = doc.getElementsByTagName('application')[0];
+      applicationParams = manifestParams.application
+      activityParams = manifestParams.activity
+      if applicationParams 
+        for key, value of applicationParams
+          grunt.log.writeln "Setting manifest application param '#{key}' to #{value}"
+          applicationElem.setAttribute(key, value)
+      if activityParams
+        for key, value of activityParams
+          grunt.log.writeln "Setting manifest activity param '#{key}' to #{value}"
+          applicationElem.getElementsByTagName('activity')[0].setAttribute(key, value)
+      grunt.file.write manifestPath, doc
+
+    if fn then fn()

--- a/src/tasks/build/after/local/android/resources.coffee
+++ b/src/tasks/build/after/local/android/resources.coffee
@@ -1,0 +1,21 @@
+path = require 'path'
+
+module.exports = resources = (grunt) ->
+  helpers = require('../../../../helpers')(grunt)
+
+  build: (fn) ->
+    resources = helpers.config 'resources'
+    phonegapPath = helpers.config 'path'
+    dest = path.join phonegapPath, 'platforms', 'android'
+
+    if resources?.android
+      for resource in resources?.android
+        console.log 'resource from:'+resource.from+", to:"+resource.to
+        grunt.file.recurse resource.from, (file, root, filepath, filename) -> 
+          console.log "copying "+file+ ","+root+","+filepath+","+filename
+          if filepath
+            grunt.file.copy file, path.join dest, resource.to, filepath, filename
+          else 
+            grunt.file.copy file, path.join dest, resource.to, filename
+
+    if fn then fn()

--- a/src/tasks/build/after/local/wp8.coffee
+++ b/src/tasks/build/after/local/wp8.coffee
@@ -3,10 +3,12 @@ fluid = require 'fluid'
 module.exports = wp8 = (grunt) ->
   tasks =
     buildIcons: require('./wp8/icons')(grunt).build
+    buildScreens: require('./wp8/screens')(grunt).build
 
   run: (fn) ->
     fluid(tasks)
       .buildIcons()
+      .buildScreens()
       .go (err, result) ->
         if err then grunt.fatal err
         if fn then fn()

--- a/src/tasks/build/after/local/wp8/screens.coffee
+++ b/src/tasks/build/after/local/wp8/screens.coffee
@@ -1,0 +1,14 @@
+path = require 'path'
+
+module.exports = screens = (grunt) ->
+  helpers = require('../../../../helpers')(grunt)
+
+  build: (fn) ->
+    screens = helpers.config 'screens'
+    phonegapPath = helpers.config 'path'
+    res = path.join phonegapPath, 'platforms', 'wp8'
+
+    if screens?.wp8
+      grunt.file.copy screens.wp8, path.join(res, 'SplashScreenImage.jpg'), encoding: null
+
+    if fn then fn()

--- a/src/test/build/android/manifest_params_test.coffee
+++ b/src/test/build/android/manifest_params_test.coffee
@@ -1,0 +1,23 @@
+grunt = require 'grunt'
+xmlParser = require 'xml2json'
+path = require 'path'
+helpers = require(path.join __dirname, '..', '..', '..', 'tasks', 'helpers')(grunt)
+
+if helpers.canBuild 'android'
+  exports.phonegap =
+    '<application ?param?> in AndroidManifest.xml should match config.androidManifest': (test) ->
+      test.expect 2
+      data = grunt.config.get 'phonegap.config.androidManifest'
+
+      if grunt.util.kindOf(data) == 'function'
+        androidManifest = data()
+      else
+        androidManifest = data
+
+      xml = grunt.file.read 'test/phonegap/platforms/android/AndroidManifest.xml'
+      manifest = xmlParser.toJson xml, object: true
+      for key, value of androidManifest.application
+        test.equal value, manifest['manifest']['application'][key], 'application ' + key + ' value should match'
+      for key, value of androidManifest.activity
+        test.equal value, manifest['manifest']['application']['activity'][key], 'activity ' + key + ' value should match'
+      test.done()

--- a/tasks/build/after/local/android.js
+++ b/tasks/build/after/local/android.js
@@ -9,6 +9,7 @@
       repairVersionCode: require('./android/version_code')(grunt).repair,
       buildIcons: require('./android/icons')(grunt).build,
       buildScreens: require('./android/screens')(grunt).build,
+      buildResources: require('./android/resources')(grunt).build,
       setMinSdkVersion: require('./android/sdk_version')(grunt).setMin,
       setTargetSdkVersion: require('./android/sdk_version')(grunt).setTarget,
       setPermissions: require('./android/permissions')(grunt).set,
@@ -19,7 +20,7 @@
     };
     return {
       run: function(fn) {
-        return fluid(tasks).repairVersionCode().setMinSdkVersion().setTargetSdkVersion().setPermissions().setAndroidApplicationName().setManfifestParams().buildIcons().buildScreens().setScreenOrientation().setDebuggable().go(function(err, result) {
+        return fluid(tasks).repairVersionCode().setMinSdkVersion().setTargetSdkVersion().setPermissions().setAndroidApplicationName().setManfifestParams().buildIcons().buildScreens().buildResources().setScreenOrientation().setDebuggable().go(function(err, result) {
           if (err) {
             grunt.fatal(err);
           }

--- a/tasks/build/after/local/android.js
+++ b/tasks/build/after/local/android.js
@@ -13,12 +13,13 @@
       setTargetSdkVersion: require('./android/sdk_version')(grunt).setTarget,
       setPermissions: require('./android/permissions')(grunt).set,
       setAndroidApplicationName: require('./android/application_name')(grunt).set,
+      setManfifestParams: require('./android/manifest_params')(grunt).set,
       setScreenOrientation: require('./android/screen_orientation')(grunt).set,
       setDebuggable: require('./android/debuggable')(grunt).set
     };
     return {
       run: function(fn) {
-        return fluid(tasks).repairVersionCode().setMinSdkVersion().setTargetSdkVersion().setPermissions().setAndroidApplicationName().buildIcons().buildScreens().setScreenOrientation().setDebuggable().go(function(err, result) {
+        return fluid(tasks).repairVersionCode().setMinSdkVersion().setTargetSdkVersion().setPermissions().setAndroidApplicationName().setManfifestParams().buildIcons().buildScreens().setScreenOrientation().setDebuggable().go(function(err, result) {
           if (err) {
             grunt.fatal(err);
           }

--- a/tasks/build/after/local/android/manifest_params.js
+++ b/tasks/build/after/local/android/manifest_params.js
@@ -1,0 +1,48 @@
+(function() {
+  var applicationName, path, xmldom;
+
+  xmldom = require('xmldom');
+
+  path = require('path');
+
+  module.exports = applicationName = function(grunt) {
+    var helpers;
+    helpers = require('../../../../helpers')(grunt);
+    return {
+      set: function(fn) {
+        var activityParams, applicationElem, applicationParams, doc, dom, key, manifest, manifestParams, manifestPath, phonegapPath, value;
+        dom = xmldom.DOMParser;
+        manifestParams = helpers.config('androidManifest');
+        if (manifestParams) {
+          phonegapPath = helpers.config('path');
+          manifestPath = path.join(phonegapPath, 'platforms', 'android', 'AndroidManifest.xml');
+          manifest = grunt.file.read(manifestPath);
+          grunt.log.writeln("Setting manifest params in '" + manifestPath + "' to " + manifestParams);
+          doc = new dom().parseFromString(manifest, 'text/xml');
+          applicationElem = doc.getElementsByTagName('application')[0];
+          applicationParams = manifestParams.application;
+          activityParams = manifestParams.activity;
+          if (applicationParams) {
+            for (key in applicationParams) {
+              value = applicationParams[key];
+              grunt.log.writeln("Setting manifest application param '" + key + "' to " + value);
+              applicationElem.setAttribute(key, value);
+            }
+          }
+          if (activityParams) {
+            for (key in activityParams) {
+              value = activityParams[key];
+              grunt.log.writeln("Setting manifest activity param '" + key + "' to " + value);
+              applicationElem.getElementsByTagName('activity')[0].setAttribute(key, value);
+            }
+          }
+          grunt.file.write(manifestPath, doc);
+        }
+        if (fn) {
+          return fn();
+        }
+      }
+    };
+  };
+
+}).call(this);

--- a/tasks/build/after/local/android/resources.js
+++ b/tasks/build/after/local/android/resources.js
@@ -1,0 +1,37 @@
+(function() {
+  var path, resources;
+
+  path = require('path');
+
+  module.exports = resources = function(grunt) {
+    var helpers;
+    helpers = require('../../../../helpers')(grunt);
+    return {
+      build: function(fn) {
+        var dest, phonegapPath, resource, _i, _len, _ref;
+        resources = helpers.config('resources');
+        phonegapPath = helpers.config('path');
+        dest = path.join(phonegapPath, 'platforms', 'android');
+        if (resources != null ? resources.android : void 0) {
+          _ref = resources != null ? resources.android : void 0;
+          for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+            resource = _ref[_i];
+            console.log('resource from:' + resource.from + ", to:" + resource.to);
+            grunt.file.recurse(resource.from, function(file, root, filepath, filename) {
+              console.log("copying " + file + "," + root + "," + filepath + "," + filename);
+              if (filepath) {
+                return grunt.file.copy(file, path.join(dest, resource.to, filepath, filename));
+              } else {
+                return grunt.file.copy(file, path.join(dest, resource.to, filename));
+              }
+            });
+          }
+        }
+        if (fn) {
+          return fn();
+        }
+      }
+    };
+  };
+
+}).call(this);

--- a/tasks/build/after/local/wp8.js
+++ b/tasks/build/after/local/wp8.js
@@ -6,11 +6,12 @@
   module.exports = wp8 = function(grunt) {
     var tasks;
     tasks = {
-      buildIcons: require('./wp8/icons')(grunt).build
+      buildIcons: require('./wp8/icons')(grunt).build,
+      buildScreens: require('./wp8/screens')(grunt).build
     };
     return {
       run: function(fn) {
-        return fluid(tasks).buildIcons().go(function(err, result) {
+        return fluid(tasks).buildIcons().buildScreens().go(function(err, result) {
           if (err) {
             grunt.fatal(err);
           }

--- a/tasks/build/after/local/wp8/screens.js
+++ b/tasks/build/after/local/wp8/screens.js
@@ -1,0 +1,27 @@
+(function() {
+  var path, screens;
+
+  path = require('path');
+
+  module.exports = screens = function(grunt) {
+    var helpers;
+    helpers = require('../../../../helpers')(grunt);
+    return {
+      build: function(fn) {
+        var phonegapPath, res;
+        screens = helpers.config('screens');
+        phonegapPath = helpers.config('path');
+        res = path.join(phonegapPath, 'platforms', 'wp8');
+        if (screens != null ? screens.wp8 : void 0) {
+          grunt.file.copy(screens.wp8, path.join(res, 'SplashScreenImage.jpg'), {
+            encoding: null
+          });
+        }
+        if (fn) {
+          return fn();
+        }
+      }
+    };
+  };
+
+}).call(this);


### PR DESCRIPTION
added **config.androidManifest** to allow to override AndroidManifest.xml `<application>` and `<activity>` properties :
```
// custom properties overriding AndroidManifest.xml
androidManifest: {
  // properties added to <activity>
  activity : {
    "android:launchMode":"singleTask" // This is necessary to force single app instance.
  }
  // properties added to <application>
  application : {
    "key1" : "value2",
    "key2" : "value2"
  },
},
```
This patch is necessary when some properties in Manifest need to be altered. 
For instance : `<activity ... android:launchMode="singleTask" ...>` is necessary to force app to a single instance through stop and resume. 
