### PR TITLE
Adds option not to clear the build folder.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -18,6 +18,7 @@ module.exports = (grunt) ->
         cordova: 'test/fixtures/.cordova'
         name: 'TestFixtureApp'
         path: 'test/phonegap'
+        cleanBeforeBuild: true
         plugins: ['./test/fixtures/org.apache.cordova.core.device']
         platforms: ['android', 'ios']
         debuggable: false

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ grunt.initConfig({
       cordova: '.cordova',
       html : 'index.html', // (Optional) You may change this to any other.html
       path: 'phonegap',
+      cleanBeforeBuild: true // when false the build path doesn't get regenerated
       plugins: ['/local/path/to/plugin', 'http://example.com/path/to/plugin.git'],
       platforms: ['android'],
       maxBuffer: 200, // You may need to raise this for iOS.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -18,6 +18,7 @@ grunt.initConfig({
       cordova: '.cordova',
       html : 'index.html', // (Optional) You may change this to any other.html
       path: 'phonegap',
+      cleanBeforeBuild: true // when false the build path doesn't get regenerated
       plugins: ['/local/path/to/plugin', 'http://example.com/path/to/plugin.git'],
       platforms: ['android'],
       maxBuffer: 200, // You may need to raise this for iOS.

--- a/src/tasks/build/base/clean.coffee
+++ b/src/tasks/build/base/clean.coffee
@@ -3,7 +3,9 @@ module.exports = clean = (grunt) ->
 
   run: (fn) ->
     path = helpers.config 'path'
+    cleanBeforeBuild = helpers.config 'cleanBeforeBuild'
     grunt.file.mkdir path unless grunt.file.exists path
-    grunt.log.writeln "Cleaning #{path}"
-    helpers.clean(path)
+    if cleanBeforeBuild
+      grunt.log.writeln "Cleaning #{path}"
+      helpers.clean(path)
     if fn then fn()

--- a/src/tasks/phonegap.coffee
+++ b/src/tasks/phonegap.coffee
@@ -7,6 +7,7 @@ module.exports = (grunt) ->
     root: 'www'
     config: 'www/config.xml'
     path: 'build'
+    cleanBeforeBuild: true
     cordova: '.cordova'
     plugins: []
     platforms: []

--- a/tasks/build/base/clean.js
+++ b/tasks/build/base/clean.js
@@ -6,13 +6,16 @@
     helpers = require('../../helpers')(grunt);
     return {
       run: function(fn) {
-        var path;
+        var cleanBeforeBuild, path;
         path = helpers.config('path');
+        cleanBeforeBuild = helpers.config('cleanBeforeBuild');
         if (!grunt.file.exists(path)) {
           grunt.file.mkdir(path);
         }
-        grunt.log.writeln("Cleaning " + path);
-        helpers.clean(path);
+        if (cleanBeforeBuild) {
+          grunt.log.writeln("Cleaning " + path);
+          helpers.clean(path);
+        }
         if (fn) {
           return fn();
         }

--- a/tasks/phonegap.js
+++ b/tasks/phonegap.js
@@ -11,6 +11,7 @@
       root: 'www',
       config: 'www/config.xml',
       path: 'build',
+      cleanBeforeBuild: true,
       cordova: '.cordova',
       plugins: [],
       platforms: [],


### PR DESCRIPTION
Setting the variable `clearBeforeBuild` to false doesn't regenerate the
build folder.

Requested on https://github.com/logankoester/grunt-phonegap/issues/98.
