### PR TITLE
Enable to choose the local CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ grunt.initConfig({
       root: 'www',
       config: 'www/config.xml',
       cordova: '.cordova',
+      cli: 'cordova', // (Optional) Default to `phonegap local`
       html : 'index.html', // (Optional) You may change this to any other.html
       path: 'phonegap',
       cleanBeforeBuild: true // when false the build path doesn't get regenerated
@@ -230,7 +231,6 @@ grunt.initConfig({
   }
 })
 ```
-
 
 
 ## Dynamic config.xml
@@ -487,6 +487,8 @@ Running `phonegap:build` with no arguments will...
 
 If you pass a specific platform as an argument (eg `grunt phonegap:build:android`), the `phonegap.config.platforms` array will be
 ignored and only that specific platform will be built.
+
+Note that by default the project will be built with `phonegap local` but you can switch to `cordova`, by setting the `phonegap.config.cli` to `cordova`. But it won't let you remote build on phonegap build servers.
 
 #### phonegap:run[:platform][:device]
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -16,6 +16,7 @@ grunt.initConfig({
       root: 'www',
       config: 'www/config.xml',
       cordova: '.cordova',
+      cli: 'cordova', // (Optional) Default to `phonegap local`
       html : 'index.html', // (Optional) You may change this to any other.html
       path: 'phonegap',
       cleanBeforeBuild: true // when false the build path doesn't get regenerated
@@ -139,4 +140,3 @@ grunt.initConfig({
   }
 })
 ```
-

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -10,6 +10,8 @@ Running `phonegap:build` with no arguments will...
 If you pass a specific platform as an argument (eg `grunt phonegap:build:android`), the `phonegap.config.platforms` array will be
 ignored and only that specific platform will be built.
 
+Note that by default the project will be built with `phonegap local` but you can switch to `cordova`, by setting the `phonegap.config.cli` to `cordova`. But it won't let you remote build on phonegap build servers.
+
 #### phonegap:run[:platform][:device]
 
 After a build is complete, the `phonegap:run` grunt task can be used to launch your app

--- a/src/tasks/build/base/plugin.coffee
+++ b/src/tasks/build/base/plugin.coffee
@@ -13,7 +13,7 @@ module.exports = plugin = (grunt) ->
     if uri.protocol() == '' and (plugin.substr(0, 1) == '.' or plugin.substr(0, 1) == '/')
       plugin = path.resolve(uri.path())
 
-    cmd = "phonegap local plugin add #{plugin} #{helpers.setVerbosity()}"
+    cmd = grunt.config.get('phonegap.config.cli') + " plugin add #{plugin} #{helpers.setVerbosity()}"
     helpers.exec cmd, fn
 
   add: (plugins, fn) ->

--- a/src/tasks/phonegap.coffee
+++ b/src/tasks/phonegap.coffee
@@ -4,6 +4,7 @@ async = require 'async'
 module.exports = (grunt) ->
 
   defaults =
+    cli: 'phonegap local'
     root: 'www'
     config: 'www/config.xml'
     path: 'build'
@@ -57,7 +58,7 @@ module.exports = (grunt) ->
     helpers.mergeConfig defaults
     release = require('./release')(grunt)
 
-    platform = @args[0] || _.first(grunt.config.get('phonegap.config.platforms'))
+    platform = @args[0] || _.first(grunt.config.get('phonegap.config.cli'))
     done = @async()
     release.on platform, -> done()
 

--- a/src/tasks/run.coffee
+++ b/src/tasks/run.coffee
@@ -1,14 +1,14 @@
 module.exports = run = (grunt) ->
   helpers = require('./helpers')(grunt)
-  
+
   # Use a local SDK to build and install your application
   # for a specific platform.
-  # 
+  #
   # @param [String] platform The platform to build and run on
   # @param [String] device One of `$ adb devices` or "emulator"
   # @param [Function] fn Optional callback to run when the child process terminates.
   local = (platform, device, fn) ->
-    cmd = "phonegap local run #{platform} #{helpers.setVerbosity()}"
+    cmd = grunt.config.get('phonegap.config.cli') + " run #{platform} #{helpers.setVerbosity()}"
     if device
       if device == 'emulator'
         cmd += ' --emulator'
@@ -18,7 +18,7 @@ module.exports = run = (grunt) ->
 
   # Use the Phonegap Build service to remotely build and install your application
   # for a specific platform.
-  # 
+  #
   # @param [String] platform The platform to build and run on
   # @param [String] device Ignored
   # @param [Function] fn Optional callback to run when the child process terminates.

--- a/tasks/build/base/plugin.js
+++ b/tasks/build/base/plugin.js
@@ -16,7 +16,7 @@
       if (uri.protocol() === '' && (plugin.substr(0, 1) === '.' || plugin.substr(0, 1) === '/')) {
         plugin = path.resolve(uri.path());
       }
-      cmd = "phonegap local plugin add " + plugin + " " + (helpers.setVerbosity());
+      cmd = grunt.config.get('phonegap.config.cli') + (" plugin add " + plugin + " " + (helpers.setVerbosity()));
       return helpers.exec(cmd, fn);
     };
     return {

--- a/tasks/phonegap.js
+++ b/tasks/phonegap.js
@@ -8,6 +8,7 @@
   module.exports = function(grunt) {
     var defaults;
     defaults = {
+      cli: 'phonegap local',
       root: 'www',
       config: 'www/config.xml',
       path: 'build',
@@ -75,7 +76,7 @@
       helpers = require('./helpers')(grunt);
       helpers.mergeConfig(defaults);
       release = require('./release')(grunt);
-      platform = this.args[0] || _.first(grunt.config.get('phonegap.config.platforms'));
+      platform = this.args[0] || _.first(grunt.config.get('phonegap.config.cli'));
       done = this.async();
       return release.on(platform, function() {
         return done();

--- a/tasks/run.js
+++ b/tasks/run.js
@@ -6,7 +6,7 @@
     helpers = require('./helpers')(grunt);
     local = function(platform, device, fn) {
       var cmd;
-      cmd = "phonegap local run " + platform + " " + (helpers.setVerbosity());
+      cmd = grunt.config.get('phonegap.config.cli') + (" run " + platform + " " + (helpers.setVerbosity()));
       if (device) {
         if (device === 'emulator') {
           cmd += ' --emulator';


### PR DESCRIPTION
In one of my project I need to use the last cordova which is `3.6.x` while phonegap is still `3.5`.

It also helps if you want to test non released version or different version of your favorite CLI.

Tests are not affected by these changes.