### PR TITLE
Properly add iPhone 6 app icon and splash screen sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,13 @@ grunt.initConfig({
           icon29x2: 'icon29x2.png',
           icon40: 'icon40.png',
           icon40x2: 'icon40x2.png',
+          icon50: 'icon50.png',
+          icon50x2: 'icon50x2.png',
           icon57: 'icon57.png',
           icon57x2: 'icon57x2.png',
+          icon60: 'icon60.png',
           icon60x2: 'icon60x2.png',
+          icon60x3: 'icon60x2.png',
           icon72: 'icon72.png',
           icon72x2: 'icon72x2.png',
           icon76: 'icon76.png',
@@ -209,7 +213,9 @@ grunt.initConfig({
           // iphone portrait
           iphonePortrait: 'screen-iphone-portrait.png',
           iphonePortraitx2: 'screen-iphone-portrait-2x.png',
-          iphone568hx2: 'screen-iphone-568h-2x.png'
+          iphone568hx2: 'screen-iphone-568h-2x.png',
+          iphone667h: 'screen-iphone-667h.png',
+          iphone736h: 'screen-iphone-736h.png'
         }
       },
 
@@ -340,6 +346,7 @@ Currently this feature supports Android, Windows Phone 8, and iOS.
           icon57x2: 'icon57x2.png',
           icon60: 'icon60.png',
           icon60x2: 'icon60x2.png',
+          icon60x3: 'icon60x2.png',
           icon72: 'icon72.png',
           icon72x2: 'icon72x2.png',
           icon76: 'icon76.png',

--- a/docs/features/app-icons.md
+++ b/docs/features/app-icons.md
@@ -34,6 +34,7 @@ Currently this feature supports Android, Windows Phone 8, and iOS.
           icon57x2: 'icon57x2.png',
           icon60: 'icon60.png',
           icon60x2: 'icon60x2.png',
+          icon60x3: 'icon60x2.png',
           icon72: 'icon72.png',
           icon72x2: 'icon72x2.png',
           icon76: 'icon76.png',

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -80,9 +80,13 @@ grunt.initConfig({
           icon29x2: 'icon29x2.png',
           icon40: 'icon40.png',
           icon40x2: 'icon40x2.png',
+          icon50: 'icon50.png',
+          icon50x2: 'icon50x2.png',
           icon57: 'icon57.png',
           icon57x2: 'icon57x2.png',
+          icon60: 'icon60.png',
           icon60x2: 'icon60x2.png',
+          icon60x3: 'icon60x2.png',
           icon72: 'icon72.png',
           icon72x2: 'icon72x2.png',
           icon76: 'icon76.png',
@@ -118,7 +122,9 @@ grunt.initConfig({
           // iphone portrait
           iphonePortrait: 'screen-iphone-portrait.png',
           iphonePortraitx2: 'screen-iphone-portrait-2x.png',
-          iphone568hx2: 'screen-iphone-568h-2x.png'
+          iphone568hx2: 'screen-iphone-568h-2x.png',
+          iphone667h: 'screen-iphone-667h.png',
+          iphone736h: 'screen-iphone-736h.png'
         }
       },
 

--- a/src/tasks/build/after/local/ios/icons.coffee
+++ b/src/tasks/build/after/local/ios/icons.coffee
@@ -40,6 +40,9 @@ module.exports = icons = (grunt) ->
     if icons?.ios?.icon60x2
       grunt.file.copy icons.ios.icon60x2, path.join(res, 'icon-60@2x.png'), encoding: null
 
+    if icons?.ios?.icon60x3
+      grunt.file.copy icons.ios.icon60x3, path.join(res, 'icon-60@3x.png'), encoding: null
+
     if icons?.ios?.icon72
       grunt.file.copy icons.ios.icon72, path.join(res, 'icon-72.png'), encoding: null
 

--- a/src/tasks/build/after/local/ios/screens.coffee
+++ b/src/tasks/build/after/local/ios/screens.coffee
@@ -31,4 +31,10 @@ module.exports = screens = (grunt) ->
     if screens?.ios?.iphone568hx2?
       grunt.file.copy screens.ios.iphone568hx2, path.join(res, 'Default-568h@2x~iphone.png'), encoding: null
 
+    if screens?.ios?.iphone667h?
+      grunt.file.copy screens.ios.iphone667h, path.join(res, 'Default-667h.png'), encoding: null
+
+    if screens?.ios?.iphone736h?
+      grunt.file.copy screens.ios.iphone736h, path.join(res, 'Default-736h.png'), encoding: null
+
     if fn then fn()

--- a/tasks/build/after/local/ios/icons.js
+++ b/tasks/build/after/local/ios/icons.js
@@ -8,7 +8,7 @@
     helpers = require('../../../../helpers')(grunt);
     return {
       build: function(fn) {
-        var appName, phonegapPath, res, _ref, _ref1, _ref10, _ref11, _ref12, _ref13, _ref14, _ref15, _ref2, _ref3, _ref4, _ref5, _ref6, _ref7, _ref8, _ref9;
+        var appName, phonegapPath, res, _ref, _ref1, _ref10, _ref11, _ref12, _ref13, _ref14, _ref15, _ref16, _ref2, _ref3, _ref4, _ref5, _ref6, _ref7, _ref8, _ref9;
         icons = helpers.config('icons');
         phonegapPath = helpers.config('path');
         appName = helpers.config('name');
@@ -63,32 +63,37 @@
             encoding: null
           });
         }
-        if (icons != null ? (_ref10 = icons.ios) != null ? _ref10.icon72 : void 0 : void 0) {
+        if (icons != null ? (_ref10 = icons.ios) != null ? _ref10.icon60x3 : void 0 : void 0) {
+          grunt.file.copy(icons.ios.icon60x3, path.join(res, 'icon-60@3x.png'), {
+            encoding: null
+          });
+        }
+        if (icons != null ? (_ref11 = icons.ios) != null ? _ref11.icon72 : void 0 : void 0) {
           grunt.file.copy(icons.ios.icon72, path.join(res, 'icon-72.png'), {
             encoding: null
           });
         }
-        if (icons != null ? (_ref11 = icons.ios) != null ? _ref11.icon72x2 : void 0 : void 0) {
+        if (icons != null ? (_ref12 = icons.ios) != null ? _ref12.icon72x2 : void 0 : void 0) {
           grunt.file.copy(icons.ios.icon72x2, path.join(res, 'icon-72@2x.png'), {
             encoding: null
           });
         }
-        if (icons != null ? (_ref12 = icons.ios) != null ? _ref12.icon76 : void 0 : void 0) {
+        if (icons != null ? (_ref13 = icons.ios) != null ? _ref13.icon76 : void 0 : void 0) {
           grunt.file.copy(icons.ios.icon76, path.join(res, 'icon-76.png'), {
             encoding: null
           });
         }
-        if (icons != null ? (_ref13 = icons.ios) != null ? _ref13.icon76x2 : void 0 : void 0) {
+        if (icons != null ? (_ref14 = icons.ios) != null ? _ref14.icon76x2 : void 0 : void 0) {
           grunt.file.copy(icons.ios.icon76x2, path.join(res, 'icon-76@2x.png'), {
             encoding: null
           });
         }
-        if (icons != null ? (_ref14 = icons.ios) != null ? _ref14.icon512 : void 0 : void 0) {
+        if (icons != null ? (_ref15 = icons.ios) != null ? _ref15.icon512 : void 0 : void 0) {
           grunt.file.copy(icons.ios.icon512, path.join(res, 'icon-512.png'), {
             encoding: null
           });
         }
-        if (icons != null ? (_ref15 = icons.ios) != null ? _ref15.icon512x2 : void 0 : void 0) {
+        if (icons != null ? (_ref16 = icons.ios) != null ? _ref16.icon512x2 : void 0 : void 0) {
           grunt.file.copy(icons.ios.icon512x2, path.join(res, 'icon-512@2x.png'), {
             encoding: null
           });

--- a/tasks/build/after/local/ios/screens.js
+++ b/tasks/build/after/local/ios/screens.js
@@ -8,7 +8,7 @@
     helpers = require('../../../../helpers')(grunt);
     return {
       build: function(fn) {
-        var appName, phonegapPath, res, _ref, _ref1, _ref2, _ref3, _ref4, _ref5, _ref6;
+        var appName, phonegapPath, res, _ref, _ref1, _ref2, _ref3, _ref4, _ref5, _ref6, _ref7, _ref8;
         screens = helpers.config('screens');
         phonegapPath = helpers.config('path');
         appName = helpers.config('name');
@@ -45,6 +45,16 @@
         }
         if ((screens != null ? (_ref6 = screens.ios) != null ? _ref6.iphone568hx2 : void 0 : void 0) != null) {
           grunt.file.copy(screens.ios.iphone568hx2, path.join(res, 'Default-568h@2x~iphone.png'), {
+            encoding: null
+          });
+        }
+        if ((screens != null ? (_ref7 = screens.ios) != null ? _ref7.iphone667h : void 0 : void 0) != null) {
+          grunt.file.copy(screens.ios.iphone667h, path.join(res, 'Default-667h.png'), {
+            encoding: null
+          });
+        }
+        if ((screens != null ? (_ref8 = screens.ios) != null ? _ref8.iphone736h : void 0 : void 0) != null) {
+          grunt.file.copy(screens.ios.iphone736h, path.join(res, 'Default-736h.png'), {
             encoding: null
           });
         }


### PR DESCRIPTION
Pull request #128 made changes to the js instead of the source coffee files. This fixes that.