### PR TITLE
Fix hanging build when cloning root directory #137

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ subdirectory containing the Phonegap project, which gets regenerated every time 
 * [Requirements](#requirements)
 * [Getting Started](#getting-started)
 * [Overview](#overview)
-* [Dynamic config.xml](#dynamic-configxml)
+* [Dynamic config.xml](#dynamic-config.xml)
 * [App Icons](#app-icons)
 * [versionCode](#versioncode)
 * [Android Debugging](#android-debugging)

--- a/src/tasks/build/base/clone_root.coffee
+++ b/src/tasks/build/base/clone_root.coffee
@@ -1,5 +1,6 @@
 path = require 'path'
 ncp = require('ncp').ncp
+ncp.limit = 512
 
 module.exports = cloneRoot = (grunt) ->
   helpers = require('../../helpers')(grunt)

--- a/tasks/build/base/clone_root.js
+++ b/tasks/build/base/clone_root.js
@@ -5,6 +5,8 @@
 
   ncp = require('ncp').ncp;
 
+  ncp.limit = 512;
+
   module.exports = cloneRoot = function(grunt) {
     var helpers;
     helpers = require('../../helpers')(grunt);


### PR DESCRIPTION
Currently hangs on "Cloning root directory". 
Fixed as per suggestion in #137 by setting `ncp.limit = 512`.
